### PR TITLE
thttpd: update from 2.26 to 2.27

### DIFF
--- a/pkgs/servers/http/thttpd/default.nix
+++ b/pkgs/servers/http/thttpd/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "thttpd-${version}";
-  version = "2.26";
+  version = "2.27";
 
   src = fetchurl {
     url = "http://acme.com/software/thttpd/${name}.tar.gz";
-    sha256 = "1idlpnwrd5fpmnfh477h1lzanavx8jxir2d8adax46zy472dg4s6";
+    sha256 = "0ykda5k1zzzag59zbd4bkzj1psavq0xnpy7vpk19rhx7mlvvri5i";
   };
 
   prePatch = ''


### PR DESCRIPTION
###### Things done:
- [x] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- [x] Built on platform(s): NixOS / OSX / Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
###### More

cc @aszlig

---

_Please note, that points are not mandatory, but rather desired._

from http://www.acme.com/software/thttpd/#releasenotes
 New in version 2.27:
-   Stats syslogs changed from LOG_INFO to LOG_NOTICE.
-   Use memmove() for self-overlapping string copies instead of strcpy().
-   Couple of subroutine name changes for consistency.
